### PR TITLE
chore(package.json): remove obsolete peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,10 +52,5 @@
     "eslint-plugin-prettier": "^3.1.4",
     "prettier": "2.1.2",
     "semantic-release": "^17.1.2"
-  },
-  "peerDependencies": {
-    "eslint": "^7.9.0",
-    "eslint-config-prettier": "^6.11.0",
-    "eslint-plugin-prettier": "^3.1.4"
   }
 }


### PR DESCRIPTION
From my understanding, since these 3 dependencies are listed as `devDependencies`, there is no added benefit in also listing them as `peerDependencies`.

When we remove them from `peerDependencies`, we will get rid of those warning messages in projects using npm-pdfreader:

```
npm WARN pdfreader@1.2.6 requires a peer of eslint@^7.9.0 but none is installed. You must install peer dependencies yourself.
npm WARN pdfreader@1.2.6 requires a peer of eslint-config-prettier@^6.11.0 but none is installed. You must install peer dependencies yourself.
npm WARN pdfreader@1.2.6 requires a peer of eslint-plugin-prettier@^3.1.4 but none is installed. You must install peer dependencies yourself.
```

Or is there any dedicated reason that we need to have them as `peerDependencies`?

