### PR TITLE
fix: Add optional support for pdf2json v2

### DIFF
--- a/PdfReader.js
+++ b/PdfReader.js
@@ -17,14 +17,16 @@ var PFParser = require("pdf2json/pdfparser"); // doc: https://github.com/modesty
 function forEachItem(pdf, handler) {
   var pageNumber = 0;
   // pdf.formImage was removed in pdf2json@2, but we keep backward compatibility too
-  var Pages = pdf.Pages || pdf.formImage.Pages
+  var Pages = pdf.Pages || pdf.formImage.Pages;
   for (var p in Pages) {
     var page = Pages[p];
     var number = ++pageNumber;
     handler(null, {
       page: number,
       width: page.Width || (pdf.formImage ? pdf.formImage.Width : 0),
-      height: page.Height || (pdf.formImage ? pdf.formImage.Pages[number - 1].Height : 0),
+      height:
+        page.Height ||
+        (pdf.formImage ? pdf.formImage.Pages[number - 1].Height : 0),
     });
     for (var t in page.Texts) {
       var item = page.Texts[t];

--- a/PdfReader.js
+++ b/PdfReader.js
@@ -16,13 +16,15 @@ var PFParser = require("pdf2json/pdfparser"); // doc: https://github.com/modesty
 
 function forEachItem(pdf, handler) {
   var pageNumber = 0;
-  for (var p in pdf.formImage.Pages) {
-    var page = pdf.formImage.Pages[p];
+  // pdf.formImage was removed in pdf2json@2, but we keep backward compatibility too
+  var Pages = pdf.Pages || pdf.formImage.Pages
+  for (var p in Pages) {
+    var page = Pages[p];
     var number = ++pageNumber;
     handler(null, {
       page: number,
-      width: pdf.formImage.Width,
-      height: pdf.formImage.Pages[number - 1].Height,
+      width: page.Width || (pdf.formImage ? pdf.formImage.Width : 0),
+      height: page.Height || (pdf.formImage ? pdf.formImage.Pages[number - 1].Height : 0),
     });
     for (var t in page.Texts) {
       var item = page.Texts[t];


### PR DESCRIPTION
This makes pdfreader compatible with version before and after pdf2json@2.

It still uses pdf2json@1.2.5 not to break functionality, because v2 contains breaking changes in JSON structure. See readme in [pdf2json](https://github.com/modesty/pdf2json) for details on breaking changes on output JSON format.

For PDF I am processing, the only difference between 1.2.5 and 2.0.0 ismissing `"clr": 0,`.

**pdf2json below v2 seams not to work with nodejs v16 and above.** I was not searching for reason, but with my changes it is easy to switch to pdf2json@2..0.0 by adding this to `package.json`:

```json
{
  "dependencies": {
    "pdfreader": "file:/home/k2s/Dev/curo/npm-pdfreader"
  },
  "resolutions": {
    "pdf2json": "2.0.0"
  }
}
```