### PR TITLE
Add basic type declarations for PDF file parsing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,21 @@
+export type InitOptions = { password?: string; debug?: boolean };
+export type Error = null | string;
+
+export type DataEntry = {
+  page?: number;
+  width?: number;
+  height?: number;
+  text?: string;
+  file?: {
+    path?: string;
+    buffer?: string;
+  };
+} | null;
+
+export type ItemHandler = (err: Error, data: DataEntry) => void;
+
+export declare class PdfReader {
+  constructor(opts: InitOptions | null): PdfReader;
+  parseFileItems(pdfFilePath: string, itemHandler: ItemHandler): void;
+  parseBuffer(buffer: Buffer, itemHandler: ItemHandler): void;
+}


### PR DESCRIPTION
This code just implements the PdfReader exportation, similar writing for all exports should be written.