### PR TITLE
Update pdf2json to v3.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "pdf2json": "3.0.1"
+        "pdf2json": "^3.0.5"
       },
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.1",
@@ -6664,25 +6664,25 @@
       }
     },
     "node_modules/pdf2json": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/pdf2json/-/pdf2json-3.0.1.tgz",
-      "integrity": "sha512-1pNsakC8F+OuFS72U+ZI0u8J/voPYYDYHj/0B/7ywYUm3w0QurkDBy3pH35kzygjgmJJVHk2a9I6gBswFF8hQQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/pdf2json/-/pdf2json-3.0.5.tgz",
+      "integrity": "sha512-Un1yLbSlk/zfwrltgguskExIioXZlFSFwsyXU0cnBorLywbTbcdzmJJEebh+U2cFCtR7y8nDs5lPHAe7ldxjZg==",
       "bundleDependencies": [
         "@xmldom/xmldom"
       ],
       "dependencies": {
-        "@xmldom/xmldom": "^0.8.6"
+        "@xmldom/xmldom": "^0.8.8"
       },
       "bin": {
-        "pdf2json": "bin/pdf2json"
+        "pdf2json": "bin/pdf2json.js"
       },
       "engines": {
-        "node": ">=14.18.0",
-        "npm": ">=8.12.1"
+        "node": ">=18.12.1",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/pdf2json/node_modules/@xmldom/xmldom": {
-      "version": "0.8.6",
+      "version": "0.8.8",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -12959,15 +12959,15 @@
       "dev": true
     },
     "pdf2json": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/pdf2json/-/pdf2json-3.0.1.tgz",
-      "integrity": "sha512-1pNsakC8F+OuFS72U+ZI0u8J/voPYYDYHj/0B/7ywYUm3w0QurkDBy3pH35kzygjgmJJVHk2a9I6gBswFF8hQQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/pdf2json/-/pdf2json-3.0.5.tgz",
+      "integrity": "sha512-Un1yLbSlk/zfwrltgguskExIioXZlFSFwsyXU0cnBorLywbTbcdzmJJEebh+U2cFCtR7y8nDs5lPHAe7ldxjZg==",
       "requires": {
-        "@xmldom/xmldom": "^0.8.6"
+        "@xmldom/xmldom": "^0.8.8"
       },
       "dependencies": {
         "@xmldom/xmldom": {
-          "version": "0.8.6",
+          "version": "0.8.8",
           "bundled": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/adrienjoly/npm-pdfreader",
   "dependencies": {
-    "pdf2json": "3.0.1"
+    "pdf2json": "^3.0.5"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.1",


### PR DESCRIPTION
The previous version (v3.0.1) didn't use the `verbosity` argument pased
to `parseBuffer`, meaning that we couldn't disable the "warning" ouput.

See:
- `parseBuffer` in `v3.0.1` https://github.com/modesty/pdf2json/blob/v3.0.1/pdfparser.js#L134-L136
- `parseBuffer` in `v3.0.5` https://github.com/modesty/pdf2json/blob/v3.0.1/pdfparser.js#L134-L136