### PR TITLE
fix(deps): upgrade pdf2json from 3.1.3 to 3.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "pdf2json": "3.1.3"
+        "pdf2json": "3.1.4"
       },
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.1",
@@ -6879,12 +6879,13 @@
       }
     },
     "node_modules/pdf2json": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/pdf2json/-/pdf2json-3.1.3.tgz",
-      "integrity": "sha512-cGP2MIz7v+w/b4vgg0OPKqhT21L/CZ73+RNmXKbKjgtnVJt2e00AqI6NZyMTp6GL6sY+r0NJOZb9gL3g37yuew==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/pdf2json/-/pdf2json-3.1.4.tgz",
+      "integrity": "sha512-rS+VapXpXZr+5lUpHmRh3ugXdFXp24p1RyG24yP1DMpqP4t0mrYNGpLtpSbWD42PnQ59GIXofxF+yWb7M+3THg==",
       "bundleDependencies": [
         "@xmldom/xmldom"
       ],
+      "license": "Apache-2.0",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.10"
       },
@@ -13327,9 +13328,9 @@
       "dev": true
     },
     "pdf2json": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/pdf2json/-/pdf2json-3.1.3.tgz",
-      "integrity": "sha512-cGP2MIz7v+w/b4vgg0OPKqhT21L/CZ73+RNmXKbKjgtnVJt2e00AqI6NZyMTp6GL6sY+r0NJOZb9gL3g37yuew==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/pdf2json/-/pdf2json-3.1.4.tgz",
+      "integrity": "sha512-rS+VapXpXZr+5lUpHmRh3ugXdFXp24p1RyG24yP1DMpqP4t0mrYNGpLtpSbWD42PnQ59GIXofxF+yWb7M+3THg==",
       "requires": {
         "@xmldom/xmldom": "^0.8.10"
       },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "https://github.com/adrienjoly/npm-pdfreader",
   "dependencies": {
-    "pdf2json": "3.1.3"
+    "pdf2json": "3.1.4"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.1",


### PR DESCRIPTION
This fixes this pdf2json issue (https://github.com/modesty/pdf2json/issues/350) which makes my app break running on Next.js 14 with node 22.6.

Hope it's useful to you! Tests seem to pass on Node 22.6 and project builds.