### PR TITLE
fix: Add abort signal

### DIFF
--- a/PdfReader.js
+++ b/PdfReader.js
@@ -60,6 +60,10 @@ PdfReader.prototype.parseFileItems = function (pdfFilePath, itemHandler) {
   });
   var verbosity = this.options.debug ? 1 : 0;
   pdfParser.loadPDF(pdfFilePath, verbosity);
+
+  this.options.signal?.addEventListener("abort", function () {
+    pdfParser.destroy();
+  });
 };
 
 /**
@@ -80,4 +84,8 @@ PdfReader.prototype.parseBuffer = function (pdfBuffer, itemHandler) {
   });
   var verbosity = this.options.debug ? 1 : 0;
   pdfParser.parseBuffer(pdfBuffer, verbosity);
+
+  this.options.signal?.addEventListener("abort", function () {
+    pdfParser.destroy();
+  });
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,8 @@
-export type InitOptions = { password?: string; debug?: boolean, signal?: AbortSignal };
+export type InitOptions = {
+  password?: string;
+  debug?: boolean;
+  signal?: AbortSignal;
+};
 export type Error = null | string;
 
 export type DataEntry = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-export type InitOptions = { password?: string; debug?: boolean };
+export type InitOptions = { password?: string; debug?: boolean, signal?: AbortSignal };
 export type Error = null | string;
 
 export type DataEntry = {


### PR DESCRIPTION
There are situations where we need to limit parsing to a specific time interval. For example, sometimes pdf2json hangs when parsing images. In these situations, and in general, it is useful to provide an abort signal so that the process stops.

The PR makes the following possible:

```
const abortSignal = AbortSignal.timeout(10000);

// reject part of outer promise, added as an illustration
abortSignal.addEventListener('abort', () =>
  reject(new Error('Maximum execution time reached')),
);

new PdfReader({ abortSignal }).parseBuffer(file, function (err, data) {
```

where we could destroy the process (and reject a promise if that's what is used).